### PR TITLE
[fix] Check if OperatorGruop already exists in the ns

### DIFF
--- a/src/main/java/io/syndesis/qe/marketplace/manifests/Bundle.java
+++ b/src/main/java/io/syndesis/qe/marketplace/manifests/Bundle.java
@@ -166,10 +166,11 @@ public class Bundle {
             .withVersion("v1alpha2")
             .build();
 
-        String operatorGroupYaml = readResource("openshift/create-operatorgroup.yaml")
-            .replaceAll("OPENSHIFT_PROJECT", namespace);
-
-        ocp.customResource(operatorGroupCrdContext).createOrReplace(namespace, operatorGroupYaml);
+        if (((List)ocp.customResource(operatorGroupCrdContext).list(namespace).get("items")).isEmpty()) {
+            String operatorGroupYaml = readResource("openshift/create-operatorgroup.yaml")
+                    .replaceAll("OPENSHIFT_PROJECT", namespace);
+            ocp.customResource(operatorGroupCrdContext).createOrReplace(namespace, operatorGroupYaml);
+        }
     }
 
     private void createOperatorGroup() throws IOException {


### PR DESCRIPTION
starting from OCP 4.9 is not possible to have 2 OperatorGroup CR in the openshift-operators namespace, this causes error during installation of the operators not-namespaced (cluster)

https://docs.openshift.com/container-platform/4.9/operators/understanding/olm/olm-understanding-operatorgroups.html#olm-operatorgroups-troubleshooting_olm-understanding-operatorgroups

https://docs.openshift.com/container-platform/4.9/release_notes/ocp-4-9-release-notes.html#ocp-4-9-olm-operator-group-status-conditions